### PR TITLE
Add forecast support

### DIFF
--- a/client.go
+++ b/client.go
@@ -6,11 +6,16 @@ package gowu
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
+	"io/ioutil"
 	"net/http"
 )
 
-const urlfmt = "http://api.wunderground.com/api/%s/conditions/q/%s/%s.json"
+const (
+	urlfmt     = "http://api.wunderground.com/api/%s/%s/q/%s/%s.json"
+	forecast   = "forecast"
+	conditions = "conditions"
+)
 
 type WuClient struct {
 	apikey string
@@ -20,22 +25,54 @@ func NewClient(key string) *WuClient {
 	return &WuClient{apikey: key}
 }
 
+func APICall(url string) ([]byte, error) {
+	res, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return body, nil
+}
+
+// Issue the request to the API
+func (w *WuClient) getForEntity(e interface{}, section, state, city string) error {
+	req_url := fmt.Sprintf(urlfmt, w.apikey, section, state, city)
+	log.Println(req_url)
+
+	body, err := APICall(req_url)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(body, e)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // Get current conditions for a city, state
 // city should have underscores between words if multiple words
 func (w *WuClient) GetConditions(city, state string) (*CurConditions, error) {
-	c := &CurConditions{}
-	req_url := fmt.Sprintf(urlfmt, w.apikey, state, city)
-	log.Println(req_url)
-	resp, err := http.Get(req_url)
+	var c CurConditions
+	err := w.getForEntity(&c, conditions, state, city)
 	if err != nil {
-		return nil, err
+		log.Error(err)
 	}
-	// Note: Weather Underground responds with 200 even if API key is wrong
-	// TODO detect using wrong api key
+	return &c, nil
+}
 
-	err = json.NewDecoder(resp.Body).Decode(c)
+func (w *WuClient) GetForecast(city, state string) (*Forecast, error) {
+	var f ForecastResponse
+	err := w.getForEntity(&f, forecast, state, city)
 	if err != nil {
-		return nil, err
+		log.Error(err)
 	}
-	return c, nil
+	return &f.Forecast, nil
 }

--- a/example/forecast.go
+++ b/example/forecast.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"fmt"
+	"github.com/peterjliu/gowu"
+	"os"
+)
+
+func main() {
+	key := os.Getenv("WU_API_KEY")
+	fmt.Printf("Using api key: %s\n", key)
+	c := gowu.NewClient(key)
+	fore, err := c.GetForecast("portland", "or")
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	fmt.Printf("Today high/low in in Portland is: %s/%s F\n", fore.Simpleforecast.Forecastday[0].High.Fahrenheit, fore.Simpleforecast.Forecastday[0].Low.Fahrenheit)
+	fmt.Printf("Tomorrow high/low in in Portland is: %s/%s F\n", fore.Simpleforecast.Forecastday[1].High.Fahrenheit, fore.Simpleforecast.Forecastday[1].Low.Fahrenheit)
+}

--- a/forecast.go
+++ b/forecast.go
@@ -1,0 +1,103 @@
+package gowu
+
+type ForecastResponse struct {
+	Response struct {
+		Version        string `json:"version"`
+		TermsofService string `json:"termsofService"`
+		Features       struct {
+			Forecast int `json:"forecast"`
+		} `json:"features"`
+	} `json:"response"`
+	Forecast Forecast `json: "forecast"`
+}
+
+type Forecast struct {
+	TxtForecast struct {
+		Date        string `json:"date"`
+		Forecastday []struct {
+			Period        int    `json:"period"`
+			Icon          string `json:"icon"`
+			IconURL       string `json:"icon_url"`
+			Title         string `json:"title"`
+			Fcttext       string `json:"fcttext"`
+			FcttextMetric string `json:"fcttext_metric"`
+			Pop           string `json:"pop"`
+		} `json:"forecastday"`
+	} `json:"txt_forecast"`
+	Simpleforecast struct {
+		Forecastday []struct {
+			Date struct {
+				Epoch          string `json:"epoch"`
+				Pretty         string `json:"pretty"`
+				Day            int    `json:"day"`
+				Month          int    `json:"month"`
+				Year           int    `json:"year"`
+				Yday           int    `json:"yday"`
+				Hour           int    `json:"hour"`
+				Min            string `json:"min"`
+				Sec            int    `json:"sec"`
+				Isdst          string `json:"isdst"`
+				Monthname      string `json:"monthname"`
+				MonthnameShort string `json:"monthname_short"`
+				WeekdayShort   string `json:"weekday_short"`
+				Weekday        string `json:"weekday"`
+				Ampm           string `json:"ampm"`
+				TzShort        string `json:"tz_short"`
+				TzLong         string `json:"tz_long"`
+			} `json:"date"`
+			Period int `json:"period"`
+			High   struct {
+				Fahrenheit string `json:"fahrenheit"`
+				Celsius    string `json:"celsius"`
+			} `json:"high"`
+			Low struct {
+				Fahrenheit string `json:"fahrenheit"`
+				Celsius    string `json:"celsius"`
+			} `json:"low"`
+			Conditions string `json:"conditions"`
+			Icon       string `json:"icon"`
+			IconURL    string `json:"icon_url"`
+			Skyicon    string `json:"skyicon"`
+			Pop        int    `json:"pop"`
+			QpfAllday  struct {
+				In float64 `json:"in"`
+				Mm int     `json:"mm"`
+			} `json:"qpf_allday"`
+			QpfDay struct {
+				In interface{} `json:"in"`
+				Mm interface{} `json:"mm"`
+			} `json:"qpf_day"`
+			QpfNight struct {
+				In float64 `json:"in"`
+				Mm int     `json:"mm"`
+			} `json:"qpf_night"`
+			SnowAllday struct {
+				In float64 `json:"in"`
+				Cm float64 `json:"cm"`
+			} `json:"snow_allday"`
+			SnowDay struct {
+				In interface{} `json:"in"`
+				Cm interface{} `json:"cm"`
+			} `json:"snow_day"`
+			SnowNight struct {
+				In float64 `json:"in"`
+				Cm float64 `json:"cm"`
+			} `json:"snow_night"`
+			Maxwind struct {
+				Mph     int    `json:"mph"`
+				Kph     int    `json:"kph"`
+				Dir     string `json:"dir"`
+				Degrees int    `json:"degrees"`
+			} `json:"maxwind"`
+			Avewind struct {
+				Mph     int    `json:"mph"`
+				Kph     int    `json:"kph"`
+				Dir     string `json:"dir"`
+				Degrees int    `json:"degrees"`
+			} `json:"avewind"`
+			Avehumidity int `json:"avehumidity"`
+			Maxhumidity int `json:"maxhumidity"`
+			Minhumidity int `json:"minhumidity"`
+		} `json:"forecastday"`
+	} `json:"simpleforecast"`
+}


### PR DESCRIPTION
Here we include forecast support using a type and do a bit of refactor on the
client to support a more generic interface to the wunderground api.